### PR TITLE
feat: add HuxBottomSheet component for mobile-first modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 
 
+## [0.24.0] - 2025-12-24
+
+### Added
+- **HuxBottomSheet**: Mobile-first modal component for menus and content
+  - Support for multiple sizes (small, medium, large, fullscreen)
+  - Optional title, subtitle, and action buttons
+  - Customizable drag handle and close button
+  - Responsive layout with smooth slide-up animations
+  - Theme-aware design with HuxTokens integration
+- **HuxActionSheet**: Semantic alternative to context menus for mobile
+  - iOS-style action list with labels and icons
+  - Support for destructive and disabled actions
+  - Built-in cancel button support
+  - Flexible item model with `HuxActionSheetItem`
+
 ## [0.23.1] - 2025-12-21
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ A modern Flutter UI package with beautiful, customizable components designed for
 [![License: MIT](https://img.shields.io/badge/License-MIT-white?style=flat&labelColor=black)](https://opensource.org/licenses/MIT)
 
 
-## Latest Release: 0.23.0
+## Latest Release: 0.24.0
 
-**HuxProgress**: New linear progress indicator component
-  - Displays task completion and status tracking with smooth animations
-  - Support for labels and value display (percentage or custom format)
-  - Multiple size variants (small, medium, large)
-  - Visual variants (primary, success, destructive)
-  - Theme-aware styling with automatic light/dark mode adaptation
+**HuxBottomSheet**: Mobile-first modal component for menus and content
+  - Support for multiple sizes (small, medium, large, fullscreen)
+  - Optional title, subtitle, and action buttons
+  - Customizable drag handle and close button
+  - Responsive layout with smooth slide-up animations
+  - Theme-aware design with HuxTokens integration
 
 [![Changelog](https://img.shields.io/badge/Changelog-View-black?style=for-the-badge&labelColor=white&logo=github&logoColor=black)](CHANGELOG.md)
 [![Docs](https://img.shields.io/badge/Docs-Browse-black?style=for-the-badge&labelColor=white&logo=readthedocs&logoColor=black)](https://docs.thehuxdesign.com)
@@ -161,6 +161,10 @@ flutter pub add hux
 ### Command
 - `HuxCommand` - Powerful command palette for quick access to actions and navigation
 - Global keyboard shortcuts integration with `HuxCommandShortcuts.wrapper`
+
+### Bottom Sheet
+- `HuxBottomSheet` - Mobile-first modal component for menus and content
+- `HuxActionSheet` - Semantic alternative to context menus for mobile
 
 ### Theme
 - `HuxTheme` - Pre-configured light and dark themes with Material 3 seed color support
@@ -580,6 +584,61 @@ HuxCommandShortcuts.wrapper(
     home: MyHomePage(),
   ),
 )
+```
+
+#### Bottom Sheet
+
+```dart
+showHuxBottomSheet(
+  context: context,
+  title: 'Settings',
+  subtitle: 'Customize your preferences',
+  size: HuxBottomSheetSize.medium,
+  child: Column(
+    children: [
+      ListTile(title: Text('Notifications')),
+      ListTile(title: Text('Privacy')),
+    ],
+  ),
+  actions: [
+    HuxButton(
+      onPressed: () => Navigator.pop(context),
+      variant: HuxButtonVariant.secondary,
+      child: Text('Cancel'),
+    ),
+    HuxButton(
+      onPressed: () => Navigator.pop(context),
+      child: Text('Save'),
+    ),
+  ],
+);
+```
+
+#### Action Sheet
+
+```dart
+showHuxActionSheet(
+  context: context,
+  title: 'Share Photo',
+  actions: [
+    HuxActionSheetItem(
+      label: 'Save to Gallery',
+      icon: LucideIcons.download,
+      onTap: () => print('Saved'),
+    ),
+    HuxActionSheetItem(
+      label: 'Share',
+      icon: LucideIcons.share2,
+      onTap: () => print('Shared'),
+    ),
+    HuxActionSheetItem(
+      label: 'Delete',
+      icon: LucideIcons.trash2,
+      isDestructive: true,
+      onTap: () => print('Deleted'),
+    ),
+  ],
+);
 ```
 
 ## Customization

--- a/doc/components/bottom-sheet.mdx
+++ b/doc/components/bottom-sheet.mdx
@@ -1,0 +1,170 @@
+---
+title: 'Bottom Sheet'
+description: 'Mobile-first modal component for menus, forms, and general content'
+---
+
+## Overview
+
+`HuxBottomSheet` is a mobile-first modal component that slides up from the bottom of the screen. It is designed to be thumb-friendly and support drag gestures, making it the standard way to present options, forms, and content on mobile devices.
+
+The package also includes `HuxActionSheet`, a specialized version of the bottom sheet for presenting a list of actionable items, similar to iOS-style action sheets.
+
+## Basic Usage
+
+### Standard Bottom Sheet
+
+```dart
+showHuxBottomSheet(
+  context: context,
+  title: 'Information',
+  child: Text('This is a bottom sheet with some content.'),
+);
+```
+
+### Action Sheet
+
+```dart
+showHuxActionSheet(
+  context: context,
+  title: 'Share Options',
+  actions: [
+    HuxActionSheetItem(
+      label: 'Email',
+      icon: LucideIcons.mail,
+      onTap: () => shareViaEmail(),
+    ),
+    HuxActionSheetItem(
+      label: 'Copy Link',
+      icon: LucideIcons.link,
+      onTap: () => copyLink(),
+    ),
+  ],
+);
+```
+
+## HuxBottomSheet
+
+### Sizes
+
+Control the height of the bottom sheet using fixed variants:
+
+- `HuxBottomSheetSize.small` - Takes ~25-30% of screen height
+- `HuxBottomSheetSize.medium` - Takes ~50% of screen height (Default)
+- `HuxBottomSheetSize.large` - Takes ~85% of screen height
+- `HuxBottomSheetSize.fullscreen` - Takes the full screen height
+
+```dart
+showHuxBottomSheet(
+  context: context,
+  title: 'Large Sheet',
+  size: HuxBottomSheetSize.large,
+  child: MyComplexForm(),
+);
+```
+
+### Header Options
+
+You can customize the header with a title, subtitle, and control buttons:
+
+- `title`: Main heading text
+- `subtitle`: Supporting text below the title
+- `showDragHandle`: Whether to show the top drag indicator (Default: true)
+- `showCloseButton`: Whether to show a close action in the header (Default: false)
+
+```dart
+showHuxBottomSheet(
+  context: context,
+  title: 'Settings',
+  subtitle: 'Configure your app experience',
+  showCloseButton: true,
+  child: SettingsList(),
+);
+```
+
+### Action Buttons
+
+Bottom sheets can include a row of action buttons at the bottom:
+
+```dart
+showHuxBottomSheet(
+  context: context,
+  title: 'Confirm Delete',
+  child: Text('Are you sure you want to delete this item?'),
+  actions: [
+    HuxButton(
+      onPressed: () => Navigator.pop(context),
+      variant: HuxButtonVariant.secondary,
+      child: Text('Cancel'),
+    ),
+    HuxButton(
+      onPressed: () => deleteItem(),
+      child: Text('Delete'),
+    ),
+  ],
+);
+```
+
+## HuxActionSheet
+
+`showHuxActionSheet` is optimized for lists of actions. Each item is represented by a `HuxActionSheetItem`.
+
+### Destructive Actions
+
+Mark actions as destructive to style them with the theme's destructive color:
+
+```dart
+HuxActionSheetItem(
+  label: 'Delete Record',
+  icon: LucideIcons.trash2,
+  isDestructive: true,
+  onTap: () => deleteRecord(),
+)
+```
+
+### Disabled Actions
+
+Actions can be disabled if they are currently unavailable:
+
+```dart
+HuxActionSheetItem(
+  label: 'Share (Login required)',
+  icon: LucideIcons.share2,
+  isDisabled: true,
+  onTap: () {},
+)
+```
+
+## API Reference
+
+### showHuxBottomSheet Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `context` | `BuildContext` | **required** | The current build context |
+| `title` | `String?` | `null` | Optional header title |
+| `subtitle` | `String?` | `null` | Optional header subtitle |
+| `child` | `Widget?` | `null` | Main content widget |
+| `actions` | `List<Widget>?` | `null` | Action buttons at the bottom |
+| `size` | `HuxBottomSheetSize` | `medium` | Height variant of the sheet |
+| `showDragHandle` | `bool` | `true` | Whether to show the top handle |
+| `showCloseButton` | `bool` | `false` | Whether to show close button |
+| `isDismissible` | `bool` | `true` | Whether tapping outside dismisses |
+| `enableDrag` | `bool` | `true` | Whether drag gestures are enabled |
+
+### showHuxActionSheet Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `context` | `BuildContext` | **required** | The current build context |
+| `actions` | `List<HuxActionSheetItem>` | **required** | List of action items |
+| `title` | `String?` | `null` | Optional header title |
+| `subtitle` | `String?` | `null` | Optional header subtitle |
+| `cancelLabel` | `String` | `'Cancel'` | Label for the cancel button |
+| `showCancel` | `bool` | `true` | Whether to show cancel button |
+
+## Accessibility
+
+- **Focus Management**: The bottom sheet handles focus trapping and restoration.
+- **Gestures**: Drag handle provides a visual hint for dismissible content.
+- **Contrast**: All text and icons follow theme-aware contrast rules.
+- **Semantic Roles**: Action items use proper list and button semantics.

--- a/doc/docs.json
+++ b/doc/docs.json
@@ -33,6 +33,7 @@
               "components/avatar",
               "components/badge",
               "components/breadcrumbs",
+              "components/bottom-sheet",
               "components/buttons",
               "components/cards",
               "components/charts",

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -231,6 +231,7 @@ class _MyHomePageState extends State<MyHomePage> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
   bool _isLoading = false;
   DateTime? _selectedDateInline;
+
   // Time picker temporarily disabled
   // TimeOfDay? _selectedTime;
 
@@ -264,6 +265,7 @@ class _MyHomePageState extends State<MyHomePage> {
   final _datePickerNavKey = GlobalKey();
   final _tooltipKey = GlobalKey();
   final _dialogKey = GlobalKey();
+  final _bottomSheetKey = GlobalKey();
   final _dropdownKey = GlobalKey();
   final _paginationKey = GlobalKey();
   final _tabsKey = GlobalKey();
@@ -378,6 +380,11 @@ class _MyHomePageState extends State<MyHomePage> {
         icon: LucideIcons.messageSquare,
       ),
       const HuxSidebarItemData(
+        id: 'bottom-sheet',
+        label: 'Bottom Sheet',
+        icon: LucideIcons.panelBottom,
+      ),
+      const HuxSidebarItemData(
         id: 'dropdown',
         label: 'Dropdown',
         icon: LucideIcons.chevronDown,
@@ -451,6 +458,7 @@ class _MyHomePageState extends State<MyHomePage> {
       'date-picker': _datePickerNavKey,
       'tooltip': _tooltipKey,
       'dialog': _dialogKey,
+      'bottom-sheet': _bottomSheetKey,
       'dropdown': _dropdownKey,
       'pagination': _paginationKey,
       'tabs': _tabsKey,
@@ -1811,6 +1819,79 @@ class _MyHomePageState extends State<MyHomePage> {
                           ),
                           const SizedBox(height: 32),
                           Container(
+                            key: _bottomSheetKey,
+                            child: SectionWithDocumentation(
+                              componentName: 'bottom-sheet',
+                              child: HuxCard(
+                                size: HuxCardSize.large,
+                                backgroundColor: HuxColors.white5,
+                                borderColor: HuxTokens.borderSecondary(context),
+                                title: 'Bottom Sheet',
+                                subtitle:
+                                    'Mobile-first modal component for options and content',
+                                child: Column(
+                                  children: [
+                                    const SizedBox(height: 32),
+                                    Wrap(
+                                      spacing: 16,
+                                      runSpacing: 16,
+                                      alignment: WrapAlignment.center,
+                                      children: [
+                                        HuxButton(
+                                          onPressed: () =>
+                                              _showSettingsBottomSheet(context),
+                                          variant: HuxButtonVariant.outline,
+                                          child:
+                                              const Text('Show Bottom Sheet'),
+                                        ),
+                                        HuxButton(
+                                          onPressed: () => showHuxActionSheet(
+                                            context: context,
+                                            title: 'Share Photo',
+                                            subtitle:
+                                                'Choose how to share this photo',
+                                            actions: [
+                                              HuxActionSheetItem(
+                                                label: 'Save to Gallery',
+                                                icon: LucideIcons.download,
+                                                onTap: () => _showSnackBar(
+                                                    'Saved to gallery'),
+                                              ),
+                                              HuxActionSheetItem(
+                                                label: 'Copy Link',
+                                                icon: LucideIcons.link,
+                                                onTap: () => _showSnackBar(
+                                                    'Link copied'),
+                                              ),
+                                              HuxActionSheetItem(
+                                                label: 'Share',
+                                                icon: LucideIcons.share2,
+                                                onTap: () =>
+                                                    _showSnackBar('Shared!'),
+                                              ),
+                                              HuxActionSheetItem(
+                                                label: 'Delete',
+                                                icon: LucideIcons.trash2,
+                                                isDestructive: true,
+                                                onTap: () =>
+                                                    _showSnackBar('Deleted!'),
+                                              ),
+                                            ],
+                                          ),
+                                          variant: HuxButtonVariant.outline,
+                                          child:
+                                              const Text('Show Action Sheet'),
+                                        ),
+                                      ],
+                                    ),
+                                    const SizedBox(height: 32),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 32),
+                          Container(
                             key: _dropdownKey,
                             child: SectionWithDocumentation(
                               componentName: 'dropdown',
@@ -1901,6 +1982,118 @@ class _MyHomePageState extends State<MyHomePage> {
     context.showHuxSnackbar(
       message: message,
       variant: HuxSnackbarVariant.info,
+    );
+  }
+
+  void _showSettingsBottomSheet(BuildContext context) {
+    bool notifications = true;
+    bool darkMode = false;
+    bool privacy = false;
+
+    showHuxBottomSheet(
+      context: context,
+      title: 'Settings',
+      subtitle: 'Customize your preferences',
+      size: HuxBottomSheetSize.medium,
+      child: StatefulBuilder(
+        builder: (context, setModalState) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildSettingsOptionStateful(
+                context,
+                'Notifications',
+                'Receive push notifications',
+                LucideIcons.bell,
+                notifications,
+                (v) => setModalState(() => notifications = v),
+              ),
+              _buildSettingsOptionStateful(
+                context,
+                'Dark Mode',
+                'Use dark theme',
+                LucideIcons.moon,
+                darkMode,
+                (v) => setModalState(() => darkMode = v),
+              ),
+              _buildSettingsOptionStateful(
+                context,
+                'Privacy',
+                'Manage your privacy settings',
+                LucideIcons.shield,
+                privacy,
+                (v) => setModalState(() => privacy = v),
+              ),
+            ],
+          );
+        },
+      ),
+      actions: [
+        HuxButton(
+          onPressed: () => Navigator.pop(context),
+          variant: HuxButtonVariant.secondary,
+          child: const Text('Cancel'),
+        ),
+        HuxButton(
+          onPressed: () {
+            Navigator.pop(context);
+            _showSnackBar('Settings saved!');
+          },
+          child: const Text('Save'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSettingsOptionStateful(
+    BuildContext context,
+    String title,
+    String subtitle,
+    IconData icon,
+    bool value,
+    ValueChanged<bool> onChanged,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: HuxTokens.surfaceSecondary(context),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(icon, size: 20, color: HuxTokens.iconPrimary(context)),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500,
+                    color: HuxTokens.textPrimary(context),
+                  ),
+                ),
+                Text(
+                  subtitle,
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: HuxTokens.textSecondary(context),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          HuxSwitch(
+            value: value,
+            onChanged: onChanged,
+          ),
+        ],
+      ),
     );
   }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -190,7 +190,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.23.1"
+    version: "0.24.0"
   image:
     dependency: transitive
     description:

--- a/lib/hux.dart
+++ b/lib/hux.dart
@@ -10,6 +10,7 @@
 /// - Customizable slider component with smooth animations
 /// - Customizable loading indicators with theme awareness
 /// - Progress indicators for task completion and status tracking
+/// - Mobile-first bottom sheets and action sheets
 /// - Beautiful data visualization charts with cristalyse integration
 /// - Right-click context menus with smart positioning
 /// - Pre-configured light and dark themes

--- a/lib/hux.dart
+++ b/lib/hux.dart
@@ -86,6 +86,7 @@ export 'src/components/navigation/hux_sidebar.dart';
 export 'src/components/navigation/hux_sidebar_item.dart';
 export 'src/components/navigation/hux_breadcrumbs.dart';
 export 'src/components/progress/hux_progress.dart';
+export 'src/components/bottom_sheet/hux_bottom_sheet.dart';
 
 // Export external dependencies
 /// LucideIcons - Beautiful icon set for Flutter applications

--- a/lib/src/components/bottom_sheet/hux_bottom_sheet.dart
+++ b/lib/src/components/bottom_sheet/hux_bottom_sheet.dart
@@ -1,0 +1,485 @@
+import 'package:flutter/material.dart';
+import '../../theme/hux_tokens.dart';
+import '../buttons/hux_button.dart';
+
+/// Size variants for HuxBottomSheet.
+enum HuxBottomSheetSize {
+  /// Small sheet taking about 25% of screen height
+  small,
+
+  /// Medium sheet taking about 50% of screen height
+  medium,
+
+  /// Large sheet taking about 75% of screen height
+  large,
+
+  /// Full screen sheet
+  fullscreen,
+}
+
+/// HuxBottomSheet is a mobile-first modal component that slides up from the bottom.
+///
+/// Bottom sheets are the standard way to present options, forms, and content
+/// on mobile devices. They are thumb-friendly and support drag gestures.
+///
+/// Example:
+/// ```dart
+/// showHuxBottomSheet(
+///   context: context,
+///   title: 'Options',
+///   child: Column(
+///     children: [
+///       ListTile(title: Text('Option 1')),
+///       ListTile(title: Text('Option 2')),
+///     ],
+///   ),
+/// );
+/// ```
+class HuxBottomSheet extends StatelessWidget {
+  /// Creates a HuxBottomSheet widget.
+  const HuxBottomSheet({
+    super.key,
+    this.title,
+    this.subtitle,
+    this.child,
+    this.actions,
+    this.size = HuxBottomSheetSize.medium,
+    this.showDragHandle = true,
+    this.showCloseButton = false,
+    this.padding,
+  });
+
+  /// Optional title text displayed in the sheet header
+  final String? title;
+
+  /// Optional subtitle text displayed below the title
+  final String? subtitle;
+
+  /// The main content widget to display in the sheet body
+  final Widget? child;
+
+  /// Optional list of action buttons displayed at the bottom
+  final List<Widget>? actions;
+
+  /// Size variant of the bottom sheet
+  final HuxBottomSheetSize size;
+
+  /// Whether to show a drag handle at the top
+  final bool showDragHandle;
+
+  /// Whether to show a close button in the header
+  final bool showCloseButton;
+
+  /// Custom padding for the content area
+  final EdgeInsets? padding;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: BoxConstraints(
+        maxHeight: _getMaxHeight(context),
+      ),
+      decoration: BoxDecoration(
+        color: HuxTokens.surfaceElevated(context),
+        borderRadius: const BorderRadius.vertical(
+          top: Radius.circular(20),
+        ),
+        border: Border(
+          top: BorderSide(
+            color: HuxTokens.borderPrimary(context),
+            width: 1,
+          ),
+          left: BorderSide(
+            color: HuxTokens.borderPrimary(context),
+            width: 1,
+          ),
+          right: BorderSide(
+            color: HuxTokens.borderPrimary(context),
+            width: 1,
+          ),
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: HuxTokens.shadowColor(context).withValues(alpha: 0.15),
+            blurRadius: 20,
+            offset: const Offset(0, -5),
+          ),
+        ],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (showDragHandle) _buildDragHandle(context),
+          if (title != null || subtitle != null || showCloseButton)
+            _buildHeader(context),
+          if (child != null) _buildContent(context),
+          if (actions?.isNotEmpty ?? false) _buildActions(context),
+        ],
+      ),
+    );
+  }
+
+  /// Builds the drag handle indicator
+  Widget _buildDragHandle(BuildContext context) {
+    return Center(
+      child: Container(
+        margin: const EdgeInsets.only(top: 12, bottom: 8),
+        width: 36,
+        height: 4,
+        decoration: BoxDecoration(
+          color: HuxTokens.borderPrimary(context),
+          borderRadius: BorderRadius.circular(2),
+        ),
+      ),
+    );
+  }
+
+  /// Builds the sheet header with title and subtitle
+  Widget _buildHeader(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        24,
+        showDragHandle ? 8 : 24,
+        showCloseButton ? 16 : 24,
+        16,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (title != null)
+                  Text(
+                    title!,
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                      color: HuxTokens.textPrimary(context),
+                    ),
+                  ),
+                if (subtitle != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      subtitle!,
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: HuxTokens.textSecondary(context),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          if (showCloseButton)
+            HuxButton(
+              onPressed: () => Navigator.of(context).pop(),
+              variant: HuxButtonVariant.ghost,
+              size: HuxButtonSize.small,
+              width: HuxButtonWidth.hug,
+              icon: Icons.close,
+              child: const SizedBox.shrink(),
+            ),
+        ],
+      ),
+    );
+  }
+
+  /// Builds the sheet content area
+  Widget _buildContent(BuildContext context) {
+    return Flexible(
+      child: SingleChildScrollView(
+        padding: padding ?? const EdgeInsets.fromLTRB(24, 0, 24, 24),
+        child: child ?? const SizedBox.shrink(),
+      ),
+    );
+  }
+
+  /// Builds the sheet actions area
+  Widget _buildActions(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
+      decoration: BoxDecoration(
+        border: Border(
+          top: BorderSide(
+            color: HuxTokens.borderSecondary(context),
+            width: 1,
+          ),
+        ),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: _buildActionButtons(),
+        ),
+      ),
+    );
+  }
+
+  /// Builds the action buttons with proper spacing
+  List<Widget> _buildActionButtons() {
+    final List<Widget> buttons = [];
+    final actionsList = actions ?? [];
+
+    for (int i = 0; i < actionsList.length; i++) {
+      if (i > 0) {
+        buttons.add(const SizedBox(width: 12));
+      }
+      buttons.add(actionsList[i]);
+    }
+
+    return buttons;
+  }
+
+  /// Gets the maximum height based on the sheet size
+  double _getMaxHeight(BuildContext context) {
+    final screenHeight = MediaQuery.of(context).size.height;
+
+    switch (size) {
+      case HuxBottomSheetSize.small:
+        return screenHeight * 0.3;
+      case HuxBottomSheetSize.medium:
+        return screenHeight * 0.5;
+      case HuxBottomSheetSize.large:
+        return screenHeight * 0.85;
+      case HuxBottomSheetSize.fullscreen:
+        return screenHeight;
+    }
+  }
+}
+
+/// Shows a HuxBottomSheet with the specified properties.
+///
+/// This is a convenience function that wraps the HuxBottomSheet widget
+/// in a showModalBottomSheet call for easy usage.
+///
+/// Example:
+/// ```dart
+/// final result = await showHuxBottomSheet<bool>(
+///   context: context,
+///   title: 'Confirm Action',
+///   child: Text('Are you sure?'),
+///   actions: [
+///     HuxButton(
+///       onPressed: () => Navigator.of(context).pop(false),
+///       variant: HuxButtonVariant.secondary,
+///       child: Text('Cancel'),
+///     ),
+///     HuxButton(
+///       onPressed: () => Navigator.of(context).pop(true),
+///       child: Text('Confirm'),
+///     ),
+///   ],
+/// );
+/// ```
+Future<T?> showHuxBottomSheet<T>({
+  required BuildContext context,
+  String? title,
+  String? subtitle,
+  Widget? child,
+  List<Widget>? actions,
+  HuxBottomSheetSize size = HuxBottomSheetSize.medium,
+  bool showDragHandle = true,
+  bool showCloseButton = false,
+  bool isDismissible = true,
+  bool enableDrag = true,
+  bool isScrollControlled = true,
+  bool useSafeArea = true,
+  EdgeInsets? padding,
+}) {
+  return showModalBottomSheet<T>(
+    context: context,
+    isDismissible: isDismissible,
+    enableDrag: enableDrag,
+    isScrollControlled: isScrollControlled,
+    useSafeArea: useSafeArea,
+    backgroundColor: Colors.transparent,
+    barrierColor: HuxTokens.overlay(context),
+    builder: (context) => HuxBottomSheet(
+      title: title,
+      subtitle: subtitle,
+      actions: actions,
+      size: size,
+      showDragHandle: showDragHandle,
+      showCloseButton: showCloseButton,
+      padding: padding,
+      child: child,
+    ),
+  );
+}
+
+/// An action item for use with HuxActionSheet.
+class HuxActionSheetItem {
+  /// Creates an action sheet item.
+  const HuxActionSheetItem({
+    required this.label,
+    required this.onTap,
+    this.icon,
+    this.isDestructive = false,
+    this.isDisabled = false,
+  });
+
+  /// The text label for the action
+  final String label;
+
+  /// Callback when the action is tapped
+  final VoidCallback onTap;
+
+  /// Optional icon to display before the label
+  final IconData? icon;
+
+  /// Whether this is a destructive action (styled in red)
+  final bool isDestructive;
+
+  /// Whether this action is disabled
+  final bool isDisabled;
+}
+
+/// Shows an iOS-style action sheet with a list of actions.
+///
+/// This is the mobile-first alternative to context menus, presenting
+/// options from the bottom of the screen.
+///
+/// Example:
+/// ```dart
+/// showHuxActionSheet(
+///   context: context,
+///   title: 'Share Photo',
+///   actions: [
+///     HuxActionSheetItem(
+///       label: 'Save to Gallery',
+///       icon: Icons.save_alt,
+///       onTap: () => savePhoto(),
+///     ),
+///     HuxActionSheetItem(
+///       label: 'Share',
+///       icon: Icons.share,
+///       onTap: () => sharePhoto(),
+///     ),
+///     HuxActionSheetItem(
+///       label: 'Delete',
+///       icon: Icons.delete,
+///       isDestructive: true,
+///       onTap: () => deletePhoto(),
+///     ),
+///   ],
+///   cancelLabel: 'Cancel',
+/// );
+/// ```
+Future<void> showHuxActionSheet({
+  required BuildContext context,
+  required List<HuxActionSheetItem> actions,
+  String? title,
+  String? subtitle,
+  String cancelLabel = 'Cancel',
+  bool showCancel = true,
+}) {
+  return showHuxBottomSheet(
+    context: context,
+    title: title,
+    subtitle: subtitle,
+    size: HuxBottomSheetSize.small,
+    showDragHandle: true,
+    showCloseButton: false,
+    padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        ...actions.map((action) => _ActionSheetTile(action: action)),
+        if (showCancel) ...[
+          const SizedBox(height: 8),
+          DecoratedBox(
+            decoration: BoxDecoration(
+              border: Border(
+                top: BorderSide(
+                  color: HuxTokens.borderSecondary(context),
+                  width: 1,
+                ),
+              ),
+            ),
+            child: _ActionSheetTile(
+              action: HuxActionSheetItem(
+                label: cancelLabel,
+                onTap: () => Navigator.of(context).pop(),
+              ),
+              isCancelButton: true,
+            ),
+          ),
+        ],
+      ],
+    ),
+  );
+}
+
+/// Internal widget for rendering action sheet items
+class _ActionSheetTile extends StatelessWidget {
+  const _ActionSheetTile({
+    required this.action,
+    this.isCancelButton = false,
+  });
+
+  final HuxActionSheetItem action;
+  final bool isCancelButton;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color textColor;
+    if (action.isDisabled) {
+      textColor = HuxTokens.textDisabled(context);
+    } else if (action.isDestructive) {
+      textColor = HuxTokens.destructive(context);
+    } else {
+      textColor = HuxTokens.textPrimary(context);
+    }
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: action.isDisabled
+            ? null
+            : () {
+                Navigator.of(context).pop();
+                action.onTap();
+              },
+        borderRadius: BorderRadius.circular(12),
+        splashColor: HuxTokens.surfaceHover(context),
+        highlightColor: HuxTokens.surfaceHover(context),
+        child: Padding(
+          padding: EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: isCancelButton ? 16 : 14,
+          ),
+          child: Row(
+            children: [
+              if (action.icon != null) ...[
+                Icon(
+                  action.icon,
+                  size: 20,
+                  color: textColor,
+                ),
+                const SizedBox(width: 12),
+              ],
+              Expanded(
+                child: Text(
+                  action.label,
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight:
+                        isCancelButton ? FontWeight.w600 : FontWeight.w500,
+                    color: textColor,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hux
 description: An open-source state of the art UI library for Flutter
-version: 0.23.1
+version: 0.24.0
 homepage: https://github.com/lofidesigner/hux
 repository: https://github.com/lofidesigner/hux
 issue_tracker: https://github.com/lofidesigner/hux/issues

--- a/test/hux_bottom_sheet_test.dart
+++ b/test/hux_bottom_sheet_test.dart
@@ -1,0 +1,443 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hux/hux.dart';
+
+void main() {
+  group('HuxBottomSheet', () {
+    testWidgets('renders with title and content', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: HuxBottomSheet(
+              title: 'Test Bottom Sheet',
+              child: const Text('Test content'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Bottom Sheet'), findsOneWidget);
+      expect(find.text('Test content'), findsOneWidget);
+    });
+
+    testWidgets('renders with subtitle', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: HuxBottomSheet(
+              title: 'Test Bottom Sheet',
+              subtitle: 'Test subtitle',
+              child: const Text('Test content'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Bottom Sheet'), findsOneWidget);
+      expect(find.text('Test subtitle'), findsOneWidget);
+      expect(find.text('Test content'), findsOneWidget);
+    });
+
+    testWidgets('renders with actions', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: HuxBottomSheet(
+              title: 'Test Bottom Sheet',
+              actions: [
+                HuxButton(
+                  onPressed: () {},
+                  child: const Text('Cancel'),
+                ),
+                HuxButton(
+                  onPressed: () {},
+                  child: const Text('Confirm'),
+                ),
+              ],
+              child: const Text('Test content'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Cancel'), findsOneWidget);
+      expect(find.text('Confirm'), findsOneWidget);
+    });
+
+    testWidgets('shows drag handle by default', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: HuxBottomSheet(
+              title: 'Test Bottom Sheet',
+              child: const Text('Test content'),
+            ),
+          ),
+        ),
+      );
+
+      // Drag handle is a Container with specific dimensions
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Container &&
+              widget.constraints?.maxWidth == 36 &&
+              widget.constraints?.maxHeight == 4,
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('hides drag handle when showDragHandle is false',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: HuxBottomSheet(
+              title: 'Test Bottom Sheet',
+              showDragHandle: false,
+              child: const Text('Test content'),
+            ),
+          ),
+        ),
+      );
+
+      // Verify the sheet still renders
+      expect(find.text('Test Bottom Sheet'), findsOneWidget);
+    });
+
+    testWidgets('shows close button when showCloseButton is true',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: HuxBottomSheet(
+              title: 'Test Bottom Sheet',
+              showCloseButton: true,
+              child: const Text('Test content'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    testWidgets('hides close button by default', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: HuxBottomSheet(
+              title: 'Test Bottom Sheet',
+              child: const Text('Test content'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.close), findsNothing);
+    });
+
+    testWidgets('applies different sizes correctly',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: HuxBottomSheet(
+              title: 'Test Bottom Sheet',
+              size: HuxBottomSheetSize.small,
+              child: const Text('Test content'),
+            ),
+          ),
+        ),
+      );
+
+      // The bottom sheet should render without errors
+      expect(find.text('Test Bottom Sheet'), findsOneWidget);
+    });
+
+    testWidgets('applies large size correctly', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: HuxBottomSheet(
+              title: 'Test Bottom Sheet',
+              size: HuxBottomSheetSize.large,
+              child: const Text('Test content'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Bottom Sheet'), findsOneWidget);
+    });
+
+    testWidgets('applies fullscreen size correctly',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: HuxBottomSheet(
+              title: 'Test Bottom Sheet',
+              size: HuxBottomSheetSize.fullscreen,
+              child: const Text('Test content'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Bottom Sheet'), findsOneWidget);
+    });
+  });
+
+  group('showHuxBottomSheet', () {
+    testWidgets('shows bottom sheet with showHuxBottomSheet function',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => HuxButton(
+                onPressed: () {
+                  showHuxBottomSheet<void>(
+                    context: context,
+                    title: 'Test Bottom Sheet',
+                    child: const Text('Test content'),
+                  );
+                },
+                child: const Text('Show Bottom Sheet'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Tap the button to show the bottom sheet
+      await tester.tap(find.text('Show Bottom Sheet'));
+      await tester.pumpAndSettle();
+
+      // The bottom sheet should be visible
+      expect(find.text('Test Bottom Sheet'), findsOneWidget);
+      expect(find.text('Test content'), findsOneWidget);
+    });
+
+    testWidgets('bottom sheet can be dismissed by tapping outside',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => HuxButton(
+                onPressed: () {
+                  showHuxBottomSheet<void>(
+                    context: context,
+                    title: 'Test Bottom Sheet',
+                    child: const Text('Test content'),
+                  );
+                },
+                child: const Text('Show Bottom Sheet'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Tap the button to show the bottom sheet
+      await tester.tap(find.text('Show Bottom Sheet'));
+      await tester.pumpAndSettle();
+
+      // Verify the bottom sheet is visible
+      expect(find.text('Test Bottom Sheet'), findsOneWidget);
+
+      // Tap outside to dismiss (tap at the top of the screen)
+      await tester.tapAt(const Offset(100, 50));
+      await tester.pumpAndSettle();
+
+      // The bottom sheet should be dismissed
+      expect(find.text('Test Bottom Sheet'), findsNothing);
+    });
+  });
+
+  group('showHuxActionSheet', () {
+    testWidgets('shows action sheet with actions',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => HuxButton(
+                onPressed: () {
+                  showHuxActionSheet(
+                    context: context,
+                    title: 'Test Action Sheet',
+                    actions: [
+                      HuxActionSheetItem(
+                        label: 'Option 1',
+                        onTap: () {},
+                      ),
+                      HuxActionSheetItem(
+                        label: 'Option 2',
+                        onTap: () {},
+                      ),
+                    ],
+                  );
+                },
+                child: const Text('Show Action Sheet'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Tap the button to show the action sheet
+      await tester.tap(find.text('Show Action Sheet'));
+      await tester.pumpAndSettle();
+
+      // The action sheet should be visible with options
+      expect(find.text('Test Action Sheet'), findsOneWidget);
+      expect(find.text('Option 1'), findsOneWidget);
+      expect(find.text('Option 2'), findsOneWidget);
+      expect(find.text('Cancel'), findsOneWidget);
+    });
+
+    testWidgets('action sheet shows custom cancel label',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => HuxButton(
+                onPressed: () {
+                  showHuxActionSheet(
+                    context: context,
+                    actions: [
+                      HuxActionSheetItem(
+                        label: 'Delete',
+                        onTap: () {},
+                        isDestructive: true,
+                      ),
+                    ],
+                    cancelLabel: 'Dismiss',
+                  );
+                },
+                child: const Text('Show Action Sheet'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Action Sheet'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Dismiss'), findsOneWidget);
+      expect(find.text('Delete'), findsOneWidget);
+    });
+
+    testWidgets('action sheet executes onTap callback',
+        (WidgetTester tester) async {
+      bool actionTapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => HuxButton(
+                onPressed: () {
+                  showHuxActionSheet(
+                    context: context,
+                    actions: [
+                      HuxActionSheetItem(
+                        label: 'Tap Me',
+                        onTap: () {
+                          actionTapped = true;
+                        },
+                      ),
+                    ],
+                  );
+                },
+                child: const Text('Show Action Sheet'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Action Sheet'));
+      await tester.pumpAndSettle();
+
+      // Tap the action
+      await tester.tap(find.text('Tap Me'));
+      await tester.pumpAndSettle();
+
+      expect(actionTapped, isTrue);
+    });
+
+    testWidgets('action sheet hides cancel button when showCancel is false',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => HuxButton(
+                onPressed: () {
+                  showHuxActionSheet(
+                    context: context,
+                    actions: [
+                      HuxActionSheetItem(
+                        label: 'Option 1',
+                        onTap: () {},
+                      ),
+                    ],
+                    showCancel: false,
+                  );
+                },
+                child: const Text('Show Action Sheet'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Action Sheet'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Option 1'), findsOneWidget);
+      expect(find.text('Cancel'), findsNothing);
+    });
+  });
+
+  group('HuxActionSheetItem', () {
+    testWidgets('renders with icon', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => HuxButton(
+                onPressed: () {
+                  showHuxActionSheet(
+                    context: context,
+                    actions: [
+                      HuxActionSheetItem(
+                        label: 'Share',
+                        icon: Icons.share,
+                        onTap: () {},
+                      ),
+                    ],
+                  );
+                },
+                child: const Text('Show Action Sheet'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show Action Sheet'));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.share), findsOneWidget);
+      expect(find.text('Share'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
- Add HuxBottomSheet widget with size variants (small, medium, large, fullscreen)
- Add showHuxBottomSheet() convenience function
- Add showHuxActionSheet() for iOS-style action menus
- Add HuxActionSheetItem for action sheet options with icon and destructive styling
- Include drag handle, title/subtitle, scrollable content, and actions area
- Export from hux.dart
- Add interactive demo to example app
- Add comprehensive test suite (17 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable Bottom Sheet with title, subtitle, content, actions, size variants (small/medium/large/fullscreen), drag-handle and optional close button.
  * Action Sheet for iOS-style menus with cancel/destructive/disabled action support.

* **Tests**
  * Comprehensive widget tests covering rendering, sizes, actions, and dismissal behavior.

* **Documentation**
  * New docs page, README examples, and changelog entry for Bottom Sheet and Action Sheet.

* **Chores**
  * Package version bumped to 0.24.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->