### PR TITLE
TabBar supporting adding/closing and drag-and-drop sorting tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **HuxTabBar**: Chrome-style tab bar component with drag-to-reorder support
+  - Dynamic tab addition and removal via `HuxTabBarController`
+  - Touch-friendly drag behavior with long-press detection
+  - Curved tab transitions for visual continuity
+  - Support for icons and closable/non-closable tabs
+  - Three size variants: small, medium, and large
+  - Comprehensive callbacks: `onActiveChanged`, `onTabsReordered`, `onTabClosed`, `onAddTab`
+  - Configurable width constraints with intrinsic sizing option
+
 ## [1.1.0] - 2026-03-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ flutter pub add hux
 
 ### Tabs
 - `HuxTabs` - Organize content into multiple panels with tab navigation
+- `HuxTabBar` - Chrome-style tab bar with drag-to-reorder and dynamic tab management
 
 ### Inputs
 - `HuxInput` - Enhanced text input with consistent styling (renamed from HuxTextField)

--- a/doc/components/tab_bar.mdx
+++ b/doc/components/tab_bar.mdx
@@ -205,7 +205,7 @@ class _TabBarExampleState extends State<TabBarExample> {
           child: ListenableBuilder(
             listenable: _controller,
             builder: (context, child) {
-              return _controller.getCentent ?? SizedBox.shrink();
+              return _controller.getContent ?? SizedBox.shrink();
             },
           ),
         ),

--- a/doc/components/tab_bar.mdx
+++ b/doc/components/tab_bar.mdx
@@ -1,0 +1,317 @@
+---
+title: Tab Bar
+description: Chrome-style tab bar with drag-to-reorder, dynamic add/close, and touch support
+---
+
+# Tab Bar
+
+A Chrome-style tab bar widget with comprehensive features for managing tabs including drag-to-reorder, dynamic tab addition/removal, and special touch handling for mobile devices.
+
+## Features
+
+- **Drag to Reorder**: Tabs can be reordered by direct mouse dragging
+- **Dynamic Add/Close**: Programmatically add and remove tabs at runtime
+- **Touch Support**: Long press before dragging to distinguish between scroll and drag operations
+- **Curved Transitions**: Smooth curved edges between active tab and content area
+- **Theme Aware**: Automatically adapts to light and dark themes
+- **Multiple Sizes**: Available in small, medium, and large variants
+
+## Basic Usage
+
+```dart
+final controller = HuxTabBarController(
+  initialTabs: [
+    HuxTabBarItem(
+      label: 'Home',
+      icon: LucideIcons.home,
+      content: Text('Home content'),
+    ),
+    HuxTabBarItem(
+      label: 'Settings',
+      icon: LucideIcons.settings,
+      content: Text('Settings content'),
+    ),
+  ],
+  initialIndex: 0,
+);
+
+HuxTabBar(
+  controller: controller,
+)
+```
+
+## Controller Usage
+
+The tab bar uses a controller to manage state:
+
+```dart
+// Add a new tab
+controller.addTab(HuxTabBarItem(
+  label: 'New Tab',
+  content: Text('New content'),
+));
+
+// Remove a tab
+controller.removeTab(index);
+
+// Set active tab
+controller.setActiveIndex(index);
+
+// Reorder tabs
+controller.reorderTabs(oldIndex, newIndex);
+```
+
+## Sizes
+
+Tab bar comes in three sizes:
+
+```dart
+// Small tabs
+HuxTabBar(
+  controller: controller,
+  size: HuxChromeTabsSize.small,
+)
+
+// Medium tabs (default)
+HuxTabBar(
+  controller: controller,
+  size: HuxChromeTabsSize.medium,
+)
+
+// Large tabs
+HuxTabBar(
+  controller: controller,
+  size: HuxChromeTabsSize.large,
+)
+```
+
+## Tab Properties
+
+### With Icons
+
+```dart
+HuxTabBarItem(
+  label: 'Documents',
+  icon: LucideIcons.fileText,
+  content: DocumentsView(),
+)
+```
+
+### Non-Closable Tabs
+
+```dart
+HuxTabBarItem(
+  label: 'Home',
+  content: HomeView(),
+  isClosable: false,
+)
+```
+
+## Callbacks
+
+### Active Tab Changed
+
+```dart
+HuxTabBar(
+  controller: controller,
+  onActiveChanged: (index) {
+    print('Active tab: $index');
+  },
+)
+```
+
+### Tabs Reordered
+
+```dart
+HuxTabBar(
+  controller: controller,
+  onTabsReordered: (oldIndex, newIndex) {
+    print('Tab moved from $oldIndex to $newIndex');
+  },
+)
+```
+
+### Tab Closed
+
+```dart
+HuxTabBar(
+  controller: controller,
+  onTabClosed: (index) {
+    print('Tab at index $index was closed');
+  },
+)
+```
+
+### Add Tab Pressed
+
+```dart
+HuxTabBar(
+  controller: controller,
+  onAddTab: () {
+    // Show dialog to add new tab
+  },
+)
+```
+
+## Dynamic Tabs Example
+
+Full example demonstrating dynamic tab management:
+
+```dart
+class TabBarExample extends StatefulWidget {
+  @override
+  State<TabBarExample> createState() => _TabBarExampleState();
+}
+
+class _TabBarExampleState extends State<TabBarExample> {
+  late final _controller = HuxTabBarController(
+    initialTabs: [
+      HuxTabBarItem(
+        label: 'Tab 1',
+        content: _buildContent('Tab 1'),
+      ),
+    ],
+    initialIndex: 0,
+  );
+  int _tabCounter = 2;
+
+  Widget _buildContent(String title) {
+    return Center(child: Text('$title content'));
+  }
+
+  void _addTab() {
+    _controller.addTab(HuxTabBarItem(
+      label: 'Tab $_tabCounter',
+      content: _buildContent('Tab $_tabCounter'),
+    ));
+    _tabCounter++;
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        HuxTabBar(
+          controller: _controller,
+          onAddTab: _addTab,
+        ),
+        Expanded(
+          child: ListenableBuilder(
+            listenable: _controller,
+            builder: (context, child) {
+              return _controller.getCentent ?? SizedBox.shrink();
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+```
+
+## Customization
+
+### Tab Width Constraints
+
+Control the minimum and maximum width of tabs:
+
+```dart
+HuxTabBar(
+  controller: controller,
+  minWidth: 100,
+  maxWidth: 250,
+)
+```
+
+### Intrinsic Width
+
+Enable or disable intrinsic width calculation for better performance:
+
+```dart
+// Enabled (default) - better performance for dynamic content
+HuxTabBar(
+  controller: controller,
+  useIntrinsicWidth: true,
+)
+
+// Disabled - better for very long tab labels
+HuxTabBar(
+  controller: controller,
+  useIntrinsicWidth: false,
+)
+```
+
+## Drag Behavior
+
+### Mouse Interaction
+
+- Click and drag tabs directly to reorder
+- 500ms delay after hover to distinguish between drag and click operations
+
+### Touch Interaction
+
+- Long press (500ms) before dragging to distinguish between scroll and drag
+- This solves the issue of accidentally triggering drag when trying to scroll the tab list
+
+## Design Details
+
+### Curved Transitions
+
+The active tab features smooth curved edges that connect seamlessly with the content area below, creating a visual continuity similar to Chrome browser tabs.
+
+### Theme Integration
+
+Tab bar automatically adapts to your theme:
+- Background colors match surface tokens
+- Text colors adjust for proper contrast
+- Border colors follow theme guidelines
+
+## Best Practices
+
+1. **Tab Labels**: Keep labels concise (1-2 words)
+2. **Icons**: Use icons to improve scannability
+3. **Controller Lifecycle**: Dispose the controller when no longer needed
+4. **Close Handlers**: Implement `onTabClosed` for important cleanup
+5. **Content**: Ensure tab content is meaningful and distinct
+6. **Touch Users**: Be aware of the long press requirement for drag operations
+
+## Accessibility
+
+- Keyboard navigation support
+- Proper focus management
+- Semantic structure for screen readers
+- ARIA labels for interactive elements
+
+## Examples
+
+### Browser-Style Interface
+
+```dart
+HuxTabBar(
+  controller: _controller,
+  size: HuxChromeTabsSize.medium,
+  onActiveChanged: (index) {
+    // Track analytics
+  },
+)
+```
+
+### Document Editor
+
+```dart
+HuxTabBar(
+  controller: _controller,
+  onTabsReordered: (oldIndex, newIndex) {
+    reorderDocuments(oldIndex, newIndex);
+  },
+  onTabClosed: (index) {
+    closeDocument(index);
+  },
+)
+```

--- a/example/lib/components/tab_bar_section.dart
+++ b/example/lib/components/tab_bar_section.dart
@@ -29,7 +29,7 @@ class _TabBarSectionState extends State<TabBarSection> {
         content: _buildContent('Settings', 'Configure your preferences'),
       ),
     ],
-    initialIndex: 5201314,
+    initialIndex: 0,
   );
   int _tabCounter = 4;
 
@@ -172,7 +172,7 @@ class _TabBarSectionState extends State<TabBarSection> {
                 builder: (context, child) {
                   return Padding(
                     padding: const EdgeInsets.all(8.0),
-                    child: _controller.getCentent ?? const Text('nothing'),
+                    child: _controller.getContent ?? const Text('No content'),
                   );
                 },
               ),

--- a/example/lib/components/tab_bar_section.dart
+++ b/example/lib/components/tab_bar_section.dart
@@ -1,0 +1,185 @@
+import 'package:example/components/section_with_documentation.dart';
+import 'package:flutter/material.dart';
+import 'package:hux/hux.dart';
+
+class TabBarSection extends StatefulWidget {
+  const TabBarSection({super.key});
+
+  @override
+  State<TabBarSection> createState() => _TabBarSectionState();
+}
+
+class _TabBarSectionState extends State<TabBarSection> {
+  HuxChromeTabsSize _selectedSize = HuxChromeTabsSize.medium;
+  late final _controller = HuxTabBarController(
+    initialTabs: [
+      HuxTabBarItem(
+        label: 'Home',
+        icon: LucideIcons.home,
+        content: _buildContent('Home', 'Welcome to the home page'),
+      ),
+      HuxTabBarItem(
+        label: 'Documents',
+        icon: LucideIcons.fileText,
+        content: _buildContent('Documents', 'Your documents are here'),
+      ),
+      HuxTabBarItem(
+        label: 'Settings',
+        icon: LucideIcons.settings,
+        content: _buildContent('Settings', 'Configure your preferences'),
+      ),
+    ],
+    initialIndex: 5201314,
+  );
+  int _tabCounter = 4;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Widget _buildContent(String title, String description) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.bold,
+              color: HuxTokens.textPrimary(context),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            description,
+            style: TextStyle(
+              fontSize: 16,
+              color: HuxTokens.textSecondary(context),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _onAddTab() {
+    _controller.addTab(
+      HuxTabBarItem(
+        label: 'Tab $_tabCounter',
+        icon: LucideIcons.file,
+        content: _buildContent(
+          'Tab $_tabCounter',
+          'This is a dynamically added tab',
+        ),
+      ),
+    );
+    _tabCounter++;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SectionWithDocumentation(
+      componentName: 'tab-bar',
+      child: HuxCard(
+        size: HuxCardSize.large,
+        backgroundColor: HuxColors.white5,
+        borderColor: HuxTokens.borderSecondary(context),
+        title: 'Tab Bar',
+        subtitle:
+            'Chrome-style tabs with drag-to-reorder and curved transitions',
+        action: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Size:',
+              style: TextStyle(
+                color: HuxTokens.textSecondary(context),
+              ),
+            ),
+            const SizedBox(width: 8),
+            SizedBox(
+              width: 140,
+              child: HuxDropdown<HuxChromeTabsSize>(
+                items: const [
+                  HuxDropdownItem(
+                    value: HuxChromeTabsSize.small,
+                    child: Text('Small'),
+                  ),
+                  HuxDropdownItem(
+                    value: HuxChromeTabsSize.medium,
+                    child: Text('Medium'),
+                  ),
+                  HuxDropdownItem(
+                    value: HuxChromeTabsSize.large,
+                    child: Text('Large'),
+                  ),
+                ],
+                value: _selectedSize,
+                onChanged: (value) {
+                  setState(() {
+                    _selectedSize = value;
+                  });
+                },
+                placeholder: 'Select size',
+                variant: HuxButtonVariant.outline,
+                size: HuxButtonSize.small,
+              ),
+            ),
+          ],
+        ),
+        child: Column(
+          children: [
+            const SizedBox(height: 16),
+            HuxTabBar(
+              controller: _controller,
+              size: _selectedSize,
+              onAddTab: _onAddTab,
+              // onTabChanged: (index) {
+              //   context.showHuxSnackbar(
+              //     message: 'Switched to: ${_controller.tabs[index].label}',
+              //     variant: HuxSnackbarVariant.info,
+              //     duration: const Duration(seconds: 1),
+              //   );
+              // },
+              // onTabsReordered: (oldIndex, newIndex) {},
+              // onTabClosed: (index) {},
+            ),
+            Container(
+              decoration: BoxDecoration(
+                color: HuxTokens.surfacePrimary(context),
+                border: Border(
+                    left: BorderSide(
+                      color: HuxTokens.borderSecondary(context),
+                      width: 1,
+                    ),
+                    right: BorderSide(
+                      color: HuxTokens.borderSecondary(context),
+                      width: 1,
+                    ),
+                    bottom: BorderSide(
+                      color: HuxTokens.borderSecondary(context),
+                      width: 1,
+                    )),
+              ),
+              height: 200,
+              alignment: Alignment.center,
+              child: ListenableBuilder(
+                listenable: _controller,
+                builder: (context, child) {
+                  return Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: _controller.getCentent ?? const Text('nothing'),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/config/navigation_items.dart
+++ b/example/lib/config/navigation_items.dart
@@ -119,6 +119,11 @@ class NavigationItems {
       icon: LucideIcons.layout,
     ),
     HuxSidebarItemData(
+      id: 'tab_bar',
+      label: 'Tab Bar',
+      icon: LucideIcons.layout,
+    ),
+    HuxSidebarItemData(
       id: 'breadcrumbs',
       label: 'Breadcrumbs',
       icon: LucideIcons.navigation,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,6 +7,7 @@ import 'components/breadcrumbs_section.dart';
 import 'components/kbd_section.dart';
 import 'components/command_section.dart';
 import 'components/tabs_section.dart';
+import 'components/tab_bar_section.dart';
 import 'components/otp_section.dart';
 import 'components/progress_section.dart';
 import 'components/bottom_sheet_section.dart';
@@ -164,6 +165,7 @@ class _MyHomePageState extends State<MyHomePage> {
   final _dropdownKey = GlobalKey();
   final _paginationKey = GlobalKey();
   final _tabsKey = GlobalKey();
+  final _tabBarKey = GlobalKey();
   final _breadcrumbsKey = GlobalKey();
   final _commandKey = GlobalKey();
   final _kbdKey = GlobalKey();
@@ -299,6 +301,7 @@ class _MyHomePageState extends State<MyHomePage> {
       'dropdown': _dropdownKey,
       'pagination': _paginationKey,
       'tabs': _tabsKey,
+      'tab_bar': _tabBarKey,
       'breadcrumbs': _breadcrumbsKey,
       'command': _commandKey,
       'kbd': _kbdKey,
@@ -590,6 +593,9 @@ class _MyHomePageState extends State<MyHomePage> {
                                 const SizedBox(height: 32),
                                 // Tabs Section
                                 TabsSection(key: _tabsKey),
+                                const SizedBox(height: 32),
+                                // Tab Bar Section
+                                TabBarSection(key: _tabBarKey),
                                 const SizedBox(height: 32),
                                 // Breadcrumbs Section
                                 BreadcrumbsSection(key: _breadcrumbsKey),

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import path_provider_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/lib/hux.dart
+++ b/lib/hux.dart
@@ -64,6 +64,7 @@ export 'src/components/feedback/hux_snackbar.dart';
 export 'src/components/avatar/hux_avatar.dart';
 export 'src/components/avatar/hux_avatar_group.dart';
 export 'src/components/tabs/hux_tabs.dart';
+export 'src/components/tabs/hux_tab_bar.dart';
 export 'src/components/tooltip/hux_tooltip.dart';
 export 'src/theme/hux_theme.dart';
 export 'src/theme/hux_colors.dart';

--- a/lib/src/components/tabs/hux_tab_bar.dart
+++ b/lib/src/components/tabs/hux_tab_bar.dart
@@ -30,7 +30,7 @@ class HuxTabBarController extends ChangeNotifier {
 
   /// Returns the content widget of the currently active tab.
   /// Returns null if there are no tabs.
-  Widget? get getCentent =>
+  Widget? get getContent =>
       _indexIsValid(_activeIndex) ? _tabs[_activeIndex].content : null;
 
   /// Returns the number of tabs.
@@ -282,7 +282,8 @@ class _HuxTabBarState extends State<HuxTabBar> {
                 },
                 onReorderStart: widget.controller.setActiveIndex,
                 itemCount: widget.controller.tabCount,
-                itemBuilder: _mouseTimer.isActive // 触控需要有延迟区分是拖拽还是滑动列表
+                itemBuilder: _mouseTimer
+                        .isActive // Touch requires delay to distinguish drag from scroll
                     ? (context, index) {
                         final tab = widget.controller.getTab(index);
                         return ReorderableDragStartListener(
@@ -514,7 +515,7 @@ class _ChromeTabPainter extends CustomPainter {
       ..style = PaintingStyle.fill;
     final path = Path();
 
-    // 左下角四分之一圆弧
+    // Bottom-left quarter circle
     path.moveTo(0, size.height);
     path.quadraticBezierTo(
       curveRadius,
@@ -524,7 +525,7 @@ class _ChromeTabPainter extends CustomPainter {
     );
     path.lineTo(curveRadius, curveRadius);
 
-    // 左上角圆弧
+    // Top-left corner arc
     path.quadraticBezierTo(
       curveRadius,
       0,
@@ -532,10 +533,10 @@ class _ChromeTabPainter extends CustomPainter {
       0,
     );
 
-    // 顶部边缘
+    // Top edge
     path.lineTo(size.width - curveRadius * 2, 0);
 
-    // 右上角圆弧
+    // Top-right corner arc
     path.quadraticBezierTo(
       size.width - curveRadius,
       0,
@@ -543,10 +544,10 @@ class _ChromeTabPainter extends CustomPainter {
       curveRadius,
     );
 
-    // 右边缘向下
+    // Right edge downward
     path.lineTo(size.width - curveRadius, size.height - curveRadius);
 
-    // 右下角四分之一圆弧（向上凹陷）
+    // Bottom-right quarter circle (concave upward)
     path.quadraticBezierTo(
       size.width - curveRadius,
       size.height,

--- a/lib/src/components/tabs/hux_tab_bar.dart
+++ b/lib/src/components/tabs/hux_tab_bar.dart
@@ -1,0 +1,567 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:hux/hux.dart';
+
+/// Controller for managing HuxChromeTabs state.
+///
+/// Use this controller to programmatically manage tabs, including adding,
+/// removing, reordering, and setting the active tab.
+class HuxTabBarController extends ChangeNotifier {
+  /// Creates a HuxTabBarController.
+  ///
+  /// [initialTabs] - The initial list of tabs. Defaults to empty list.
+  /// [initialIndex] - The index of the initially active tab. Defaults to 0.
+  HuxTabBarController({
+    List<HuxTabBarItem> initialTabs = const [],
+    int initialIndex = 0,
+  })  : _tabs = List.from(initialTabs),
+        _activeIndex = initialIndex > -1 && initialIndex < initialTabs.length
+            ? initialIndex
+            : 0;
+
+  bool _indexIsValid(int index) => index > -1 && index < _tabs.length;
+
+  final List<HuxTabBarItem> _tabs;
+  int _activeIndex;
+
+  /// Returns the index of the currently active tab.
+  int get activeIndex => _activeIndex;
+
+  /// Returns the content widget of the currently active tab.
+  /// Returns null if there are no tabs.
+  Widget? get getCentent =>
+      _indexIsValid(_activeIndex) ? _tabs[_activeIndex].content : null;
+
+  /// Returns the number of tabs.
+  int get tabCount => _tabs.length;
+
+  /// Adds a new tab to the tab bar.
+  ///
+  /// [tab] - The tab item to add.
+  /// [autoActivate] - Whether to automatically activate the newly added tab. Default is true.
+  void addTab(HuxTabBarItem tab, [bool autoActivate = true]) {
+    _tabs.add(tab);
+    if (autoActivate) _activeIndex = _tabs.length - 1;
+    notifyListeners();
+  }
+
+  /// Removes a tab at the specified index.
+  ///
+  /// [index] - The index of the tab to remove.
+  void removeTab(int index) {
+    if (_tabs.isEmpty) return;
+    _tabs.removeAt(index);
+    if (_activeIndex >= _tabs.length && _tabs.isNotEmpty) {
+      _activeIndex = _tabs.length - 1;
+    } else if (_activeIndex > index && _activeIndex > 0) {
+      _activeIndex--;
+    }
+    if (_tabs.isEmpty) {
+      _activeIndex = 0;
+    }
+    notifyListeners();
+  }
+
+  /// Sets the active tab by index.
+  ///
+  /// [index] - The index of the tab to activate.
+  void setActiveIndex(int index) {
+    if (index >= 0 && index < _tabs.length) {
+      _activeIndex = index;
+      notifyListeners();
+    }
+  }
+
+  /// Reorders tabs by moving a tab from [oldIndex] to [newIndex].
+  ///
+  /// [oldIndex] - The current index of the tab to move.
+  /// [newIndex] - The target index where the tab should be moved to.
+  void reorderTabs(int oldIndex, int newIndex) {
+    if (oldIndex == newIndex) return;
+
+    if (newIndex > oldIndex) {
+      newIndex -= 1;
+    }
+
+    final item = _tabs.removeAt(oldIndex);
+    _tabs.insert(newIndex, item);
+
+    // Update active index
+    if (_activeIndex == oldIndex) {
+      _activeIndex = newIndex;
+    } else if (oldIndex < _activeIndex && newIndex >= _activeIndex) {
+      _activeIndex--;
+    } else if (oldIndex > _activeIndex && newIndex <= _activeIndex) {
+      _activeIndex++;
+    }
+
+    notifyListeners();
+  }
+
+  /// Get a tab at a given index
+  HuxTabBarItem getTab(int index) {
+    assert(_indexIsValid(index), 'Invalid index');
+    return _tabs[index];
+  }
+}
+
+/// Orientation for HuxChromeTabs.
+enum HuxTabBarOrientation {
+  /// Horizontal tabs (like Chrome browser)
+  horizontal,
+
+  /// Vertical tabs (for future support)
+  vertical,
+}
+
+/// Size variants for HuxChromeTabs.
+enum HuxChromeTabsSize {
+  /// Small tabs for compact layouts
+  small,
+
+  /// Medium tabs for standard layouts (default)
+  medium,
+
+  /// Large tabs for prominent navigation
+  large,
+}
+
+/// HuxChromeTabItem represents a single Chrome-style tab with its content and properties.
+class HuxTabBarItem {
+  /// Creates a HuxChromeTabItem.
+  const HuxTabBarItem({
+    required this.label,
+    required this.content,
+    this.icon,
+    this.isClosable = true,
+  });
+
+  /// The text label displayed on the tab
+  final String label;
+
+  /// The content widget displayed when this tab is active
+  final Widget content;
+
+  /// Optional icon displayed before the label
+  final IconData? icon;
+
+  /// Whether this tab can be closed
+  final bool isClosable;
+}
+
+/// A Chrome-style tab bar widget with drag-to-reorder support.
+///
+/// Supports dynamic tab addition, removal, and drag-to-reorder functionality.
+/// For touch devices, long press is required before dragging to distinguish
+/// between scroll and drag operations.
+class HuxTabBar extends StatefulWidget {
+  /// Creates a HuxTabBar widget.
+  ///
+  /// [controller] - The HuxTabBarController to manage tab state (required).
+  /// [size] - The size variant of the tabs. Defaults to medium.
+  /// [orientation] - The orientation of tabs. Defaults to horizontal.
+  /// [onActiveChanged] - Callback when the active tab changes.
+  /// [onTabsReordered] - Callback when tabs are reordered.
+  /// [onTabClosed] - Callback when a tab is closed.
+  /// [onAddTab] - Callback when the add button is pressed.
+  /// [maxWidth] - Maximum width for each tab.
+  /// [minWidth] - Minimum width for each tab. Defaults to 80.
+  /// [useIntrinsicWidth] - Whether to use intrinsic width calculation.
+  const HuxTabBar({
+    super.key,
+    required this.controller,
+    this.size = HuxChromeTabsSize.medium,
+    this.orientation = HuxTabBarOrientation.horizontal,
+    this.onActiveChanged,
+    this.onTabsReordered,
+    this.onTabClosed,
+    this.onAddTab,
+    this.maxWidth,
+    this.minWidth = 80,
+    this.useIntrinsicWidth = true,
+  });
+
+  /// Controller for managing tabs state
+  final HuxTabBarController controller;
+
+  /// Size variant of the tabs
+  final HuxChromeTabsSize size;
+
+  /// Orientation of the tabs
+  final HuxTabBarOrientation orientation;
+
+  /// Callback when the active tab changes
+  final ValueChanged<int>? onActiveChanged;
+
+  /// Callback when tabs are reordered
+  final void Function(int oldIndex, int newIndex)? onTabsReordered;
+
+  /// Callback when a tab is closed
+  final ValueChanged<int>? onTabClosed;
+
+  /// Callback when the add button is pressed
+  final VoidCallback? onAddTab;
+
+  /// Maximum width for each tab (null for auto-sizing based on content)
+  final double? maxWidth;
+
+  /// Minimum width for each tab
+  final double minWidth;
+
+  /// Whether to enable intrinsic sizing for better performance
+  final bool useIntrinsicWidth;
+
+  @override
+  State<HuxTabBar> createState() => _HuxTabBarState();
+}
+
+class _HuxTabBarState extends State<HuxTabBar> {
+  HuxButtonSize get _buttonSize => HuxButtonSize.values[widget.size.index];
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onControllerChanged);
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onControllerChanged);
+    super.dispose();
+  }
+
+  void _onControllerChanged() {
+    setState(() {});
+  }
+
+  void _onTabTap(int index) {
+    widget.controller.setActiveIndex(index);
+    widget.onActiveChanged?.call(index);
+  }
+
+  void _onTabClose(int index) {
+    widget.controller.removeTab(index);
+    widget.onTabClosed?.call(index);
+    widget.onActiveChanged?.call(widget.controller.activeIndex);
+  }
+
+  void _onReorder(int oldIndex, int newIndex) {
+    widget.controller.reorderTabs(oldIndex, newIndex);
+    widget.onTabsReordered?.call(oldIndex, newIndex);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: _getTabHeight(),
+      decoration: BoxDecoration(
+        color: HuxTokens.surfaceSecondary(context),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Listener(
+              onPointerHover: (_) {
+                final wasInactive = !_mouseTimer.isActive;
+                _mouseTimer.cancel();
+                _mouseTimer = Timer(Duration(milliseconds: 500), () {
+                  setState(() {}); // _mouseTimer.isActive = false;
+                });
+                if (wasInactive) setState(() {}); // isActive = true;
+              },
+              child: ReorderableListView.builder(
+                scrollDirection: Axis.horizontal,
+                buildDefaultDragHandles: false,
+                onReorder: _onReorder,
+                proxyDecorator: (child, index, animation) {
+                  return Material(
+                    color: Colors.transparent,
+                    child: child,
+                  );
+                },
+                onReorderStart: widget.controller.setActiveIndex,
+                itemCount: widget.controller.tabCount,
+                itemBuilder: _mouseTimer.isActive // 触控需要有延迟区分是拖拽还是滑动列表
+                    ? (context, index) {
+                        final tab = widget.controller.getTab(index);
+                        return ReorderableDragStartListener(
+                          key: ValueKey(tab.label + index.toString()),
+                          index: index,
+                          child: _buildTab(context, index),
+                        );
+                      }
+                    : (context, index) {
+                        final tab = widget.controller.getTab(index);
+                        return ReorderableDelayedDragStartListener(
+                          key: ValueKey(tab.label + index.toString()),
+                          index: index,
+                          child: _buildTab(context, index),
+                        );
+                      },
+              ),
+            ),
+          ),
+          if (widget.onAddTab != null)
+            // Add button
+            Padding(
+              padding: EdgeInsets.all(3),
+              child: HuxButton(
+                variant: HuxButtonVariant.ghost,
+                size: _buttonSize,
+                onPressed: widget.onAddTab,
+                icon: Icons.add,
+                child: SizedBox.shrink(),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Timer _mouseTimer = Timer(Duration.zero, () {})..cancel();
+
+  Widget _buildTab(BuildContext context, int index) {
+    final tab = widget.controller.getTab(index);
+    final isActive = index == widget.controller.activeIndex;
+
+    final tabContent = Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: _getHorizontalPadding(),
+        vertical: _getVerticalPadding(),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          if (tab.icon != null) ...[
+            Icon(
+              tab.icon,
+              size: _getIconSize(),
+              color: isActive
+                  ? HuxTokens.textPrimary(context)
+                  : HuxTokens.textSecondary(context),
+            ),
+            const SizedBox(width: 8),
+          ],
+          ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: widget.maxWidth ?? double.infinity,
+            ),
+            child: Text(
+              tab.label,
+              style: TextStyle(
+                fontSize: _getFontSize(),
+                fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
+                color: isActive
+                    ? HuxTokens.textPrimary(context)
+                    : HuxTokens.textSecondary(context),
+              ),
+              overflow: TextOverflow.ellipsis,
+              maxLines: 1,
+            ),
+          ),
+          if (tab.isClosable) ...[
+            const SizedBox(width: 8),
+            HuxButton(
+              width: HuxButtonWidth.expand,
+              widthValue: 5,
+              variant: HuxButtonVariant.ghost,
+              size: _buttonSize,
+              onPressed: () => _onTabClose(index),
+              icon: Icons.close,
+              child: SizedBox.shrink(),
+            ),
+          ],
+        ],
+      ),
+    );
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: () => _onTabTap(index),
+        onTertiaryTapUp: (_) => _onTabClose(index),
+        child: widget.useIntrinsicWidth
+            ? IntrinsicWidth(
+                child: Stack(
+                  children: [
+                    CustomPaint(
+                      painter: _ChromeTabPainter(
+                        isActive: isActive,
+                        backgroundColor: isActive
+                            ? HuxTokens.surfacePrimary(context)
+                            : Colors.transparent,
+                        borderColor: HuxTokens.borderSecondary(context),
+                      ),
+                      child: SizedBox(
+                        height: double.infinity,
+                        width: double.infinity,
+                      ),
+                    ),
+                    tabContent,
+                  ],
+                ),
+              )
+            : Container(
+                constraints: BoxConstraints(
+                  minWidth: widget.minWidth,
+                  maxWidth: widget.maxWidth ?? double.infinity,
+                ),
+                child: Stack(
+                  children: [
+                    CustomPaint(
+                      painter: _ChromeTabPainter(
+                        isActive: isActive,
+                        backgroundColor: isActive
+                            ? HuxTokens.surfacePrimary(context)
+                            : Colors.transparent,
+                        borderColor: HuxTokens.borderSecondary(context),
+                      ),
+                      child: SizedBox(
+                        height: double.infinity,
+                        width: double.infinity,
+                      ),
+                    ),
+                    tabContent,
+                  ],
+                ),
+              ),
+      ),
+    );
+  }
+
+  double _getTabHeight() {
+    switch (widget.size) {
+      case HuxChromeTabsSize.small:
+        return 32;
+      case HuxChromeTabsSize.medium:
+        return 40;
+      case HuxChromeTabsSize.large:
+        return 48;
+    }
+  }
+
+  double _getHorizontalPadding() {
+    switch (widget.size) {
+      case HuxChromeTabsSize.small:
+        return 12;
+      case HuxChromeTabsSize.medium:
+        return 16;
+      case HuxChromeTabsSize.large:
+        return 20;
+    }
+  }
+
+  double _getVerticalPadding() {
+    switch (widget.size) {
+      case HuxChromeTabsSize.small:
+        return 6;
+      case HuxChromeTabsSize.medium:
+        return 8;
+      case HuxChromeTabsSize.large:
+        return 12;
+    }
+  }
+
+  double _getIconSize() {
+    switch (widget.size) {
+      case HuxChromeTabsSize.small:
+        return 14;
+      case HuxChromeTabsSize.medium:
+        return 16;
+      case HuxChromeTabsSize.large:
+        return 18;
+    }
+  }
+
+  double _getFontSize() {
+    switch (widget.size) {
+      case HuxChromeTabsSize.small:
+        return 12;
+      case HuxChromeTabsSize.medium:
+        return 14;
+      case HuxChromeTabsSize.large:
+        return 16;
+    }
+  }
+}
+
+/// Custom painter for Chrome-style tab with curved bottom edges
+class _ChromeTabPainter extends CustomPainter {
+  _ChromeTabPainter({
+    required this.isActive,
+    required this.backgroundColor,
+    required this.borderColor,
+  });
+
+  final bool isActive;
+  final Color backgroundColor;
+  final Color borderColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (!isActive) return;
+
+    const curveRadius = 8.0;
+
+    final borderPaint = Paint()
+      ..color = borderColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1;
+    final paint = Paint()
+      ..color = backgroundColor
+      ..style = PaintingStyle.fill;
+    final path = Path();
+
+    // 左下角四分之一圆弧
+    path.moveTo(0, size.height);
+    path.quadraticBezierTo(
+      curveRadius,
+      size.height,
+      curveRadius,
+      size.height - curveRadius,
+    );
+    path.lineTo(curveRadius, curveRadius);
+
+    // 左上角圆弧
+    path.quadraticBezierTo(
+      curveRadius,
+      0,
+      curveRadius * 2,
+      0,
+    );
+
+    // 顶部边缘
+    path.lineTo(size.width - curveRadius * 2, 0);
+
+    // 右上角圆弧
+    path.quadraticBezierTo(
+      size.width - curveRadius,
+      0,
+      size.width - curveRadius,
+      curveRadius,
+    );
+
+    // 右边缘向下
+    path.lineTo(size.width - curveRadius, size.height - curveRadius);
+
+    // 右下角四分之一圆弧（向上凹陷）
+    path.quadraticBezierTo(
+      size.width - curveRadius,
+      size.height,
+      size.width,
+      size.height,
+    );
+
+    canvas.drawPath(path, paint);
+    canvas.drawPath(path, borderPaint);
+  }
+
+  @override
+  bool shouldRepaint(_ChromeTabPainter oldDelegate) {
+    return oldDelegate.isActive != isActive ||
+        oldDelegate.backgroundColor != backgroundColor ||
+        oldDelegate.borderColor != borderColor;
+  }
+}

--- a/test/hux_tab_bar_test.dart
+++ b/test/hux_tab_bar_test.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hux/hux.dart';
+
+void main() {
+  group('HuxTabBarController', () {
+    test('initializes with correct values', () {
+      final controller = HuxTabBarController(
+        initialTabs: [
+          const HuxTabBarItem(
+            label: 'Tab 1',
+            content: Text('Content 1'),
+          ),
+          const HuxTabBarItem(
+            label: 'Tab 2',
+            content: Text('Content 2'),
+          ),
+        ],
+        initialIndex: 1,
+      );
+
+      expect(controller.tabCount, 2);
+      expect(controller.activeIndex, 1);
+      expect(controller.getContent, isA<Text>());
+    });
+
+    test('handles invalid initial index', () {
+      final controller = HuxTabBarController(
+        initialTabs: [
+          const HuxTabBarItem(
+            label: 'Tab 1',
+            content: Text('Content 1'),
+          ),
+        ],
+        initialIndex: 10,
+      );
+
+      expect(controller.activeIndex, 0);
+    });
+
+    test('adds tab correctly', () {
+      final controller = HuxTabBarController(
+        initialTabs: [
+          const HuxTabBarItem(
+            label: 'Tab 1',
+            content: Text('Content 1'),
+          ),
+        ],
+      );
+
+      controller.addTab(
+        const HuxTabBarItem(
+          label: 'Tab 2',
+          content: Text('Content 2'),
+        ),
+      );
+
+      expect(controller.tabCount, 2);
+      expect(controller.activeIndex, 1);
+    });
+
+    test('removes tab correctly', () {
+      final controller = HuxTabBarController(
+        initialTabs: [
+          const HuxTabBarItem(
+            label: 'Tab 1',
+            content: Text('Content 1'),
+          ),
+          const HuxTabBarItem(
+            label: 'Tab 2',
+            content: Text('Content 2'),
+          ),
+        ],
+        initialIndex: 1,
+      );
+
+      controller.removeTab(1);
+
+      expect(controller.tabCount, 1);
+      expect(controller.activeIndex, 0);
+    });
+
+    test('sets active index correctly', () {
+      final controller = HuxTabBarController(
+        initialTabs: [
+          const HuxTabBarItem(
+            label: 'Tab 1',
+            content: Text('Content 1'),
+          ),
+          const HuxTabBarItem(
+            label: 'Tab 2',
+            content: Text('Content 2'),
+          ),
+        ],
+      );
+
+      controller.setActiveIndex(1);
+
+      expect(controller.activeIndex, 1);
+    });
+
+    test('reorders tabs correctly', () {
+      final controller = HuxTabBarController(
+        initialTabs: [
+          const HuxTabBarItem(
+            label: 'Tab 1',
+            content: Text('Content 1'),
+          ),
+          const HuxTabBarItem(
+            label: 'Tab 2',
+            content: Text('Content 2'),
+          ),
+          const HuxTabBarItem(
+            label: 'Tab 3',
+            content: Text('Content 3'),
+          ),
+        ],
+        initialIndex: 0,
+      );
+
+      controller.reorderTabs(0, 2);
+
+      expect(controller.getTab(1).label, 'Tab 1');
+      expect(controller.activeIndex, 1);
+    });
+  });
+
+  group('HuxTabBar Widget', () {
+    testWidgets('renders tabs correctly', (WidgetTester tester) async {
+      final controller = HuxTabBarController(
+        initialTabs: [
+          const HuxTabBarItem(
+            label: 'Tab 1',
+            content: Text('Content 1'),
+          ),
+          const HuxTabBarItem(
+            label: 'Tab 2',
+            content: Text('Content 2'),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: HuxTabBar(
+              controller: controller,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Tab 1'), findsOneWidget);
+      expect(find.text('Tab 2'), findsOneWidget);
+    });
+
+    testWidgets('switches tabs on tap', (WidgetTester tester) async {
+      final controller = HuxTabBarController(
+        initialTabs: [
+          const HuxTabBarItem(
+            label: 'Tab 1',
+            content: Text('Content 1'),
+          ),
+          const HuxTabBarItem(
+            label: 'Tab 2',
+            content: Text('Content 2'),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: HuxTabBar(
+              controller: controller,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Tab 2'));
+      await tester.pump();
+
+      expect(controller.activeIndex, 1);
+    });
+
+    testWidgets('calls onAddTab when add button is pressed',
+        (WidgetTester tester) async {
+      final controller = HuxTabBarController(
+        initialTabs: [
+          const HuxTabBarItem(
+            label: 'Tab 1',
+            content: Text('Content 1'),
+          ),
+        ],
+      );
+
+      var addTabCalled = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: HuxTabBar(
+              controller: controller,
+              onAddTab: () {
+                addTabCalled = true;
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pump();
+
+      expect(addTabCalled, true);
+    });
+  });
+}


### PR DESCRIPTION
As the title says, and I've considered some details, such as

- When using touch operations, a long press is required to drag and drop to sort in order to solve the problem of being unable to swipe the tab list with touch

- Middle mouse button closes tab

However, the bad news is that it seems you've already been working on this part, and my code may also have quality issues

Anyway, hope it helps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced HuxTabBar: a Chrome-style tab bar component with drag-to-reorder functionality, dynamic tab add/remove operations, touch-based long-press dragging, smooth curved transitions, three size variants, and configurable appearance with icon support and closable/non-closable tabs.

* **Documentation**
  * Added comprehensive documentation, interactive examples, and detailed implementation guides for the new HuxTabBar component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->