### PR TITLE
feat: add focusNode support to HuxInput for RawAutocomplete

### DIFF
--- a/lib/src/components/inputs/hux_input.dart
+++ b/lib/src/components/inputs/hux_input.dart
@@ -28,6 +28,7 @@ class HuxInput extends StatefulWidget {
   /// Creates a HuxInput widget.
   const HuxInput({
     super.key,
+    this.focusNode,
     this.controller,
     this.label,
     this.hint,
@@ -47,6 +48,8 @@ class HuxInput extends StatefulWidget {
     this.width,
   });
 
+  /// Focus node for managing focus state of the text field
+  final FocusNode? focusNode;
   /// Controller for the text field
   final TextEditingController? controller;
 
@@ -182,6 +185,7 @@ class _HuxInputState extends State<HuxInput> {
           child: SizedBox(
             height: _getHeight(),
             child: TextFormField(
+              focusNode: widget.focusNode,
               controller: widget.controller,
               obscureText: _obscureText,
               enabled: widget.enabled,


### PR DESCRIPTION
## Title
feat: add optional `focusNode` support to `HuxInput` for `RawAutocomplete` or `Autocomplete `

## Description
This PR adds an optional `focusNode` parameter to `HuxInput` and passes it through to the underlying `TextFormField`.

### Why
`RawAutocomplete` and similar Flutter flows require external focus control for proper keyboard navigation and overlay behavior. Exposing `focusNode` in `HuxInput` enables this integration while preserving existing usage.

### What changed
- Added `focusNode` to `HuxInput` constructor
- Added `final FocusNode? focusNode;` to `HuxInput`
- Wired it into `TextFormField(focusNode: widget.focusNode)`

### Scope / Compatibility
- Backward-compatible: `focusNode` is optional
- No visual design-token or theming changes
- No behavior changes for consumers that do not provide `focusNode`

## Testing
- [x] `flutter analyze` passes
- [x] `flutter test` passes
- [x] Manual verification in example/app:
  - `HuxInput` works with no `focusNode`
  - external `FocusNode` can request/release focus
  - `RawAutocomplete` flow works with provided focus node

## Pre-submission Checklist
- [x] Code follows style guidelines
- [x] All tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for external focus control in the HuxInput component, allowing users to manage focus state programmatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->